### PR TITLE
Add Comet browser support

### DIFF
--- a/Sources/GetWindowsCLI/main.swift
+++ b/Sources/GetWindowsCLI/main.swift
@@ -2,7 +2,7 @@ import AppKit
 
 func getActiveBrowserTabURLAppleScriptCommand(_ appId: String) -> String? {
 	switch appId {
-	case "com.google.Chrome", "com.google.Chrome.beta", "com.google.Chrome.dev", "com.google.Chrome.canary", "com.brave.Browser", "com.brave.Browser.beta", "com.brave.Browser.nightly", "com.microsoft.edgemac", "com.microsoft.edgemac.Beta", "com.microsoft.edgemac.Dev", "com.microsoft.edgemac.Canary", "com.mighty.app", "com.ghostbrowser.gb1", "com.bookry.wavebox", "com.pushplaylabs.sidekick", "com.operasoftware.Opera", "com.operasoftware.OperaNext", "com.operasoftware.OperaDeveloper", "com.vivaldi.Vivaldi", "ru.yandex.desktop.yandex-browser", "com.operasoftware.OperaGX":
+	case "com.google.Chrome", "com.google.Chrome.beta", "com.google.Chrome.dev", "com.google.Chrome.canary", "com.brave.Browser", "com.brave.Browser.beta", "com.brave.Browser.nightly", "com.microsoft.edgemac", "com.microsoft.edgemac.Beta", "com.microsoft.edgemac.Dev", "com.microsoft.edgemac.Canary", "com.mighty.app", "com.ghostbrowser.gb1", "com.bookry.wavebox", "com.pushplaylabs.sidekick", "com.operasoftware.Opera", "com.operasoftware.OperaNext", "com.operasoftware.OperaDeveloper", "com.vivaldi.Vivaldi", "ru.yandex.desktop.yandex-browser", "com.operasoftware.OperaGX", "ai.perplexity.comet":
 		return """
 			tell app id \"\(appId)\"
 				set window_url to URL of active tab of front window


### PR DESCRIPTION
#### Summary
Added Comet browser bundle id to support extracting the current tab information on this chromium-based browser.

#### Verifications: 
Ran local integration tests (not committed to the repo) to validate the url is extracted from my current tab on Comet:

```
Testing Comet...
  Comet is running (PID: 97965)
  Comet data extracted successfully
  URL: https://linear.app/now/self-driving-saas
  Title: Self-driving SaaS: When software runs itself - Linear
  Mode: normal
  
```