### PR TITLE
Bump version up to 9.1.2-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rize-io/get-windows",
-	"version": "9.1.1",
+	"version": "9.1.2-beta.0",
 	"description": "Get metadata about the active window (title, id, bounds, owner, URL, etc)",
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
This is to release updated lib with latest [commit](https://github.com/rize-io/get-windows/pull/16)