### PR TITLE
Bumping version again 9.1.2-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rize-io/get-windows",
-	"version": "9.1.2-beta.0",
+	"version": "9.1.2-beta.1",
 	"description": "Get metadata about the active window (title, id, bounds, owner, URL, etc)",
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
I realized that I published version 9.1.2-beta.0 a month ago by mistake without publishing to github.  I plan on deprecating that one on npm and uploading again for 9.1.2-beta.1