### PR TITLE
Reduce Windows I/O reads by caching COM instances and file version lookups

### DIFF
--- a/Sources/windows/main.cc
+++ b/Sources/windows/main.cc
@@ -283,7 +283,7 @@ IUIAutomationElement* findUIAElementRecursively(IUIAutomationTreeWalker* pTreeWa
 	return nullptr;
 }
 
-HRESULT findUIAElement(HWND hwnd, IUIAutomationElement** ppAddressBar, ElementMatcher matcher) {
+HRESULT findUIAElement(HWND hwnd, IUIAutomationElement** ppAddressBar, ElementMatcher matcher, bool& searchTruncated) {
 	// Create the automation object + tree walker once per call (reused across
 	// the whole recursive walk) instead of per recursive node visit.
 	CComPtr<IUIAutomation> pAutomation;
@@ -306,6 +306,13 @@ HRESULT findUIAElement(HWND hwnd, IUIAutomationElement** ppAddressBar, ElementMa
 
 	int iteration = 0;
 	IUIAutomationElement* result = findUIAElementRecursively(pTreeWalker, pRootElement, 0, iteration, matcher);
+
+	// Report when the walk gave up at the iteration cap without finding a match,
+	// so callers can distinguish "no such element" from "search bailed early".
+	if (!result && iteration >= MAX_UIA_ITERATIONS) {
+		searchTruncated = true;
+	}
+
 	if (result) {
 		*ppAddressBar = result;
 		return S_OK;
@@ -379,7 +386,7 @@ ElementMatcher operaBrowserAddressBarMatcher = [](IUIAutomationElement* element)
 	return isEditControlType(element) && matchElementName(element, "Address field");
 };
 
-std::string getUrl(HWND hwnd, const OwnerWindowInfo& ownerInfo) {
+std::string getUrl(HWND hwnd, const OwnerWindowInfo& ownerInfo, bool& searchTruncated) {
 	std::string url;
 	ElementMatcher matcher;
 
@@ -404,7 +411,7 @@ std::string getUrl(HWND hwnd, const OwnerWindowInfo& ownerInfo) {
 	}
 
 	CComPtr<IUIAutomationElement> pAddressBar;
-	HRESULT hr = findUIAElement(hwnd, &pAddressBar, matcher);
+	HRESULT hr = findUIAElement(hwnd, &pAddressBar, matcher, searchTruncated);
 
 	if (SUCCEEDED(hr) && pAddressBar)
 	{
@@ -446,7 +453,7 @@ ElementMatcher operaBrowserIncognitoMatcher = [](IUIAutomationElement* element) 
 	return matchElementName(element, "Opera (Private)");
 };
 
-std::string getMode(HWND hwnd, const OwnerWindowInfo& ownerInfo) {
+std::string getMode(HWND hwnd, const OwnerWindowInfo& ownerInfo, bool& searchTruncated) {
 	std::string mode;
 	ElementMatcher matcher;
 
@@ -471,7 +478,7 @@ std::string getMode(HWND hwnd, const OwnerWindowInfo& ownerInfo) {
 	}
 
 	CComPtr<IUIAutomationElement> pIncognito;
-	HRESULT hr = findUIAElement(hwnd, &pIncognito, matcher);
+	HRESULT hr = findUIAElement(hwnd, &pIncognito, matcher, searchTruncated);
 
 	if (SUCCEEDED(hr) && pIncognito)
 	{
@@ -580,10 +587,12 @@ Napi::Value getWindowInformation(const HWND &hwnd, const Napi::CallbackInfo &inf
 		HRESULT hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
 
 		if (SUCCEEDED(hr)) {
-			std::string url = getUrl(hwnd, ownerInfo);
-			std::string mode = getMode(hwnd, ownerInfo);
+			bool searchTruncated = false;
+			std::string url = getUrl(hwnd, ownerInfo, searchTruncated);
+			std::string mode = getMode(hwnd, ownerInfo, searchTruncated);
 			activeWinObj.Set(Napi::String::New(env, "url"), Napi::String::New(env, url));
 			activeWinObj.Set(Napi::String::New(env, "mode"), Napi::String::New(env, mode));
+			activeWinObj.Set(Napi::String::New(env, "searchTruncated"), Napi::Boolean::New(env, searchTruncated));
 		}
 
 		CoUninitialize();

--- a/Sources/windows/main.cc
+++ b/Sources/windows/main.cc
@@ -16,14 +16,46 @@
 #include <functional>
 #include <tuple>
 #include <regex>
+#include <unordered_map>
+#include <mutex>
 
 typedef int(__stdcall *lp_GetScaleFactorForMonitor)(HMONITOR, DEVICE_SCALE_FACTOR *);
 typedef std::function<bool(IUIAutomationElement*)> ElementMatcher;
+
+// Cap recursive UIA tree walks to avoid excessive cross-process I/O
+static const int MAX_UIA_ITERATIONS = 500;
 
 struct OwnerWindowInfo {
 	std::string path;
 	std::string name;
 };
+
+// Cache for file version info (process path -> display name).
+// Avoids re-reading large EXEs (e.g. Chrome 200+ MB) on every call.
+static std::unordered_map<std::string, std::string> fileVersionCache;
+
+// Singleton UIA COM instance and tree walker, created once per process
+// instead of per-recursive-call. Eliminates thousands of CoCreateInstance
+// calls per tree walk.
+static CComPtr<IUIAutomation> g_pAutomation;
+static CComPtr<IUIAutomationTreeWalker> g_pTreeWalker;
+
+static bool ensureUIAutomation() {
+	if (g_pAutomation) return true;
+
+	HRESULT hr = CoCreateInstance(__uuidof(CUIAutomation), nullptr,
+		CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation),
+		(void**)&g_pAutomation);
+	if (FAILED(hr)) return false;
+
+	hr = g_pAutomation->get_RawViewWalker(&g_pTreeWalker);
+	if (FAILED(hr)) {
+		g_pAutomation.Release();
+		return false;
+	}
+
+	return true;
+}
 
 template <typename T>
 T getValueFromCallbackData(const Napi::CallbackInfo &info, unsigned handleIndex) {
@@ -70,6 +102,8 @@ std::string getWindowTitle(const HWND hwnd) {
 	std::wstring ws(t);
 	std::string title = toUtf8(ws);
 
+	delete[] t;
+
 	return title;
 }
 
@@ -99,7 +133,7 @@ std::string getDescriptionFromFileVersionInfo(const BYTE *pBlock) {
 	return "";
 }
 
-// Return process path and name
+// Return process path and name, with cached file version info lookups
 OwnerWindowInfo getProcessPathAndName(const HANDLE &phlde) {
 	DWORD dwSize{MAX_PATH};
 	wchar_t exeName[MAX_PATH]{};
@@ -107,10 +141,20 @@ OwnerWindowInfo getProcessPathAndName(const HANDLE &phlde) {
 	std::string path = toUtf8(exeName);
 	std::string name = getFileName(path);
 
+	// Check cache before reading the EXE from disk
+	auto it = fileVersionCache.find(path);
+	if (it != fileVersionCache.end()) {
+		if (!it->second.empty()) {
+			name = it->second;
+		}
+		return {path, name};
+	}
+
 	DWORD dwHandle = 0;
 	wchar_t *wspath(exeName);
 	DWORD infoSize = GetFileVersionInfoSizeW(wspath, &dwHandle);
 
+	std::string cachedName;
 	if (infoSize != 0) {
 		BYTE *pVersionInfo = new BYTE[infoSize];
 		std::unique_ptr<BYTE[]> skey_automatic_cleanup(pVersionInfo);
@@ -118,9 +162,12 @@ OwnerWindowInfo getProcessPathAndName(const HANDLE &phlde) {
 			std::string nname = getDescriptionFromFileVersionInfo(pVersionInfo);
 			if (nname != "") {
 				name = nname;
+				cachedName = nname;
 			}
 		}
 	}
+
+	fileVersionCache[path] = cachedName;
 
 	return {path, name};
 }
@@ -201,6 +248,11 @@ IUIAutomationElement* findUIAElementRecursively(IUIAutomationElement* element, i
 		return nullptr;
 	}
 
+	// Bail out after visiting too many nodes
+	if (iteration >= MAX_UIA_ITERATIONS) {
+		return nullptr;
+	}
+
 	iteration++;
 
 	CONTROLTYPEID controlId;
@@ -218,22 +270,14 @@ IUIAutomationElement* findUIAElementRecursively(IUIAutomationElement* element, i
 		return element;
 	}
 
-	CComPtr<IUIAutomationTreeWalker> pTreeWalker;
-	CComPtr<IUIAutomation> pAutomation;
-
-	hr = CoCreateInstance(__uuidof(CUIAutomation), nullptr, CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation), (void**)&pAutomation);
-	if (FAILED(hr)) {
-		return nullptr;
-	}
-
-	hr = pAutomation->get_RawViewWalker(&pTreeWalker);
-	if (FAILED(hr)) {
+	// Use the singleton tree walker instead of creating COM instances per call
+	if (!g_pTreeWalker) {
 		return nullptr;
 	}
 
 	if (!skipChildren) {
 		CComPtr<IUIAutomationElement> pFirstChild;
-		hr = pTreeWalker->GetFirstChildElement(element, &pFirstChild);
+		hr = g_pTreeWalker->GetFirstChildElement(element, &pFirstChild);
 		if (SUCCEEDED(hr)) {
 			IUIAutomationElement* result = findUIAElementRecursively(pFirstChild, depth + 1, iteration, matcher);
 			if (result) {
@@ -243,7 +287,7 @@ IUIAutomationElement* findUIAElementRecursively(IUIAutomationElement* element, i
 	}
 
 	CComPtr<IUIAutomationElement> pNextSibling;
-	hr = pTreeWalker->GetNextSiblingElement(element, &pNextSibling);
+	hr = g_pTreeWalker->GetNextSiblingElement(element, &pNextSibling);
 	if (SUCCEEDED(hr)) {
 		IUIAutomationElement* result = findUIAElementRecursively(pNextSibling, depth, iteration, matcher, controlId == UIA_DocumentControlTypeId);
 		if (result) {
@@ -255,16 +299,12 @@ IUIAutomationElement* findUIAElementRecursively(IUIAutomationElement* element, i
 }
 
 HRESULT findUIAElement(HWND hwnd, IUIAutomationElement** ppAddressBar, ElementMatcher matcher) {
-	HRESULT hr = S_OK;
-	CComPtr<IUIAutomation> pAutomation;
-
-	hr = CoCreateInstance(__uuidof(CUIAutomation), nullptr, CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation), (void**)&pAutomation);
-	if (FAILED(hr)) {
-		return hr;
+	if (!ensureUIAutomation()) {
+		return E_FAIL;
 	}
 
 	CComPtr<IUIAutomationElement> pRootElement;
-	hr = pAutomation->ElementFromHandle(hwnd, &pRootElement);
+	HRESULT hr = g_pAutomation->ElementFromHandle(hwnd, &pRootElement);
 	if (FAILED(hr)) {
 		return hr;
 	}

--- a/Sources/windows/main.cc
+++ b/Sources/windows/main.cc
@@ -33,29 +33,7 @@ struct OwnerWindowInfo {
 // Cache for file version info (process path -> display name).
 // Avoids re-reading large EXEs (e.g. Chrome 200+ MB) on every call.
 static std::unordered_map<std::string, std::string> fileVersionCache;
-
-// Singleton UIA COM instance and tree walker, created once per process
-// instead of per-recursive-call. Eliminates thousands of CoCreateInstance
-// calls per tree walk.
-static CComPtr<IUIAutomation> g_pAutomation;
-static CComPtr<IUIAutomationTreeWalker> g_pTreeWalker;
-
-static bool ensureUIAutomation() {
-	if (g_pAutomation) return true;
-
-	HRESULT hr = CoCreateInstance(__uuidof(CUIAutomation), nullptr,
-		CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation),
-		(void**)&g_pAutomation);
-	if (FAILED(hr)) return false;
-
-	hr = g_pAutomation->get_RawViewWalker(&g_pTreeWalker);
-	if (FAILED(hr)) {
-		g_pAutomation.Release();
-		return false;
-	}
-
-	return true;
-}
+static std::mutex fileVersionCacheMutex;
 
 template <typename T>
 T getValueFromCallbackData(const Napi::CallbackInfo &info, unsigned handleIndex) {
@@ -142,12 +120,15 @@ OwnerWindowInfo getProcessPathAndName(const HANDLE &phlde) {
 	std::string name = getFileName(path);
 
 	// Check cache before reading the EXE from disk
-	auto it = fileVersionCache.find(path);
-	if (it != fileVersionCache.end()) {
-		if (!it->second.empty()) {
-			name = it->second;
+	{
+		std::lock_guard<std::mutex> lock(fileVersionCacheMutex);
+		auto it = fileVersionCache.find(path);
+		if (it != fileVersionCache.end()) {
+			if (!it->second.empty()) {
+				name = it->second;
+			}
+			return {path, name};
 		}
-		return {path, name};
 	}
 
 	DWORD dwHandle = 0;
@@ -167,7 +148,10 @@ OwnerWindowInfo getProcessPathAndName(const HANDLE &phlde) {
 		}
 	}
 
-	fileVersionCache[path] = cachedName;
+	{
+		std::lock_guard<std::mutex> lock(fileVersionCacheMutex);
+		fileVersionCache[path] = cachedName;
+	}
 
 	return {path, name};
 }
@@ -239,7 +223,7 @@ bool isSupportedBrowser(const OwnerWindowInfo& ownerInfo) {
 	return isGoogleChrome(ownerInfo) || isBraveBrowser(ownerInfo) || isMicrosoftEdge(ownerInfo) || isFirefox(ownerInfo) || isOperaBrowser(ownerInfo);
 }
 
-IUIAutomationElement* findUIAElementRecursively(IUIAutomationElement* element, int depth, int& iteration, ElementMatcher matcher, bool skipChildren = false) {
+IUIAutomationElement* findUIAElementRecursively(IUIAutomationTreeWalker* pTreeWalker, IUIAutomationElement* element, int depth, int& iteration, ElementMatcher matcher, bool skipChildren = false) {
 	if (element == nullptr) {
 		return nullptr;
 	}
@@ -248,8 +232,11 @@ IUIAutomationElement* findUIAElementRecursively(IUIAutomationElement* element, i
 		return nullptr;
 	}
 
-	// Bail out after visiting too many nodes
+	// Bail out after visiting too many nodes. Log when the cap trips so that
+	// silent misses (no URL / "normal" mode on a deep browser tree) are visible.
 	if (iteration >= MAX_UIA_ITERATIONS) {
+		std::cerr << "[get-windows] UIA tree walk hit MAX_UIA_ITERATIONS ("
+			<< MAX_UIA_ITERATIONS << "); aborting search early" << std::endl;
 		return nullptr;
 	}
 
@@ -270,16 +257,17 @@ IUIAutomationElement* findUIAElementRecursively(IUIAutomationElement* element, i
 		return element;
 	}
 
-	// Use the singleton tree walker instead of creating COM instances per call
-	if (!g_pTreeWalker) {
+	// Reuse the tree walker created once per findUIAElement call instead of
+	// creating COM instances per recursive node visit.
+	if (!pTreeWalker) {
 		return nullptr;
 	}
 
 	if (!skipChildren) {
 		CComPtr<IUIAutomationElement> pFirstChild;
-		hr = g_pTreeWalker->GetFirstChildElement(element, &pFirstChild);
+		hr = pTreeWalker->GetFirstChildElement(element, &pFirstChild);
 		if (SUCCEEDED(hr)) {
-			IUIAutomationElement* result = findUIAElementRecursively(pFirstChild, depth + 1, iteration, matcher);
+			IUIAutomationElement* result = findUIAElementRecursively(pTreeWalker, pFirstChild, depth + 1, iteration, matcher);
 			if (result) {
 				return result;
 			}
@@ -287,9 +275,9 @@ IUIAutomationElement* findUIAElementRecursively(IUIAutomationElement* element, i
 	}
 
 	CComPtr<IUIAutomationElement> pNextSibling;
-	hr = g_pTreeWalker->GetNextSiblingElement(element, &pNextSibling);
+	hr = pTreeWalker->GetNextSiblingElement(element, &pNextSibling);
 	if (SUCCEEDED(hr)) {
-		IUIAutomationElement* result = findUIAElementRecursively(pNextSibling, depth, iteration, matcher, controlId == UIA_DocumentControlTypeId);
+		IUIAutomationElement* result = findUIAElementRecursively(pTreeWalker, pNextSibling, depth, iteration, matcher, controlId == UIA_DocumentControlTypeId);
 		if (result) {
 			return result;
 		}
@@ -299,18 +287,28 @@ IUIAutomationElement* findUIAElementRecursively(IUIAutomationElement* element, i
 }
 
 HRESULT findUIAElement(HWND hwnd, IUIAutomationElement** ppAddressBar, ElementMatcher matcher) {
-	if (!ensureUIAutomation()) {
-		return E_FAIL;
+	// Create the automation object + tree walker once per call (reused across
+	// the whole recursive walk) instead of per recursive node visit.
+	CComPtr<IUIAutomation> pAutomation;
+	HRESULT hr = CoCreateInstance(__uuidof(CUIAutomation), nullptr, CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation), (void**)&pAutomation);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	CComPtr<IUIAutomationTreeWalker> pTreeWalker;
+	hr = pAutomation->get_RawViewWalker(&pTreeWalker);
+	if (FAILED(hr)) {
+		return hr;
 	}
 
 	CComPtr<IUIAutomationElement> pRootElement;
-	HRESULT hr = g_pAutomation->ElementFromHandle(hwnd, &pRootElement);
+	hr = pAutomation->ElementFromHandle(hwnd, &pRootElement);
 	if (FAILED(hr)) {
 		return hr;
 	}
 
 	int iteration = 0;
-	IUIAutomationElement* result = findUIAElementRecursively(pRootElement, 0, iteration, matcher);
+	IUIAutomationElement* result = findUIAElementRecursively(pTreeWalker, pRootElement, 0, iteration, matcher);
 	if (result) {
 		*ppAddressBar = result;
 		return S_OK;

--- a/Sources/windows/main.cc
+++ b/Sources/windows/main.cc
@@ -232,11 +232,8 @@ IUIAutomationElement* findUIAElementRecursively(IUIAutomationTreeWalker* pTreeWa
 		return nullptr;
 	}
 
-	// Bail out after visiting too many nodes. Log when the cap trips so that
-	// silent misses (no URL / "normal" mode on a deep browser tree) are visible.
+	// Bail out after visiting too many nodes
 	if (iteration >= MAX_UIA_ITERATIONS) {
-		std::cerr << "[get-windows] UIA tree walk hit MAX_UIA_ITERATIONS ("
-			<< MAX_UIA_ITERATIONS << "); aborting search early" << std::endl;
 		return nullptr;
 	}
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,6 +95,21 @@ export type LinuxResult = {
 
 export type WindowsResult = {
 	platform: 'windows';
+
+	/**
+	URL of the active browser tab if the active window is a supported browser (Chrome, Edge, Brave, Firefox, or Opera).
+	*/
+	url?: string;
+
+	/**
+	Browsing mode of the active browser window: `'incognito'` for a private/incognito window, otherwise `'normal'`.
+	*/
+	mode?: string;
+
+	/**
+	`true` when the UI Automation tree walk used to read `url`/`mode` hit its node cap before finding a match, meaning those values may be missing or inaccurate for this window. Used for diagnosing missed reads on deep browser UI trees.
+	*/
+	searchTruncated?: boolean;
 } & BaseResult;
 
 export type Result = MacOSResult | LinuxResult | WindowsResult;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -43,5 +43,8 @@ if (result) {
 	} else {
 		expectType<WindowsResult>(result);
 		expectError(result.owner.bundleId);
+		expectType<string | undefined>(result.url);
+		expectType<string | undefined>(result.mode);
+		expectType<boolean | undefined>(result.searchTruncated);
 	}
 }


### PR DESCRIPTION
Reduces the I/O read volume reported in the field by enterprise customers when polling the active window on Windows. Supersedes #28 with the same optimizations plus fixes for that PR's review feedback.

## What was wrong

`getActiveWindow()` is polled every ~15s. When a browser is focused it triggers two full UI Automation tree walks (one for the URL, one for incognito detection), and the previous code created a fresh `CUIAutomation` COM instance + `RawViewWalker` on **every recursive node visit** — thousands of `CoCreateInstance` calls per poll. Separately, `getProcessPathAndName` read the entire target EXE from disk (Chrome is 200+ MB) on every poll to pull a display name.

## Changes

1. **Reuse the UIA COM instance + tree walker per call.** The `IUIAutomation` object and `RawViewWalker` are now created once per `findUIAElement` call and threaded through the recursion, instead of per node visited. This is the bulk of the read-count reduction.

2. **File version info cache.** `getProcessPathAndName` caches the display name by process path, so each EXE is read from disk once instead of every poll. Cache reads and writes are guarded by a mutex for the worker-thread path.

3. **Iteration cap on UIA tree walks.** `MAX_UIA_ITERATIONS = 500` bounds the walk so a pathological/deep browser tree can't spin thousands of cross-process calls per poll.

4. **`searchTruncated` flag.** When the walk hits the iteration cap without finding a match, the returned window object now sets `searchTruncated: true`. This lets the consumer distinguish "element genuinely absent" from "search bailed early on a deep tree," and measure how often the 500 cap actually trips in the field (it's an unmeasured heuristic — the flag is how we'd justify changing it).

Also fixes a memory leak in `getWindowTitle` (missing `delete[]` on the WCHAR buffer), and documents the already-emitted `url` / `mode` fields on `WindowsResult` (previously untyped) alongside the new `searchTruncated` field.

## Review fixes vs #28

- Dropped the process-lifetime `g_pAutomation` / `g_pTreeWalker` singletons. They dangled across the per-poll `CoInitializeEx` / `CoUninitialize` scope, causing stale pointers, `RPC_E_WRONG_THREAD`, and `Release()` after COM teardown at exit. Reusing the objects per-call keeps the I/O win while staying inside the live COM scope.
- Guarded the `fileVersionCache` data race with a mutex.

## Testing

- `tsd` type tests pass (covers the new `url` / `mode` / `searchTruncated` typings).
- Native code is Windows-only (MSVC + Windows SDK via node-pre-gyp) and must be built/run on Windows. Smoke test: build with `npm run build:windows`, then call `activeWindow()` against a normal tab (`mode: 'normal'`), an incognito window (`mode: 'incognito'`), and a non-browser app. To exercise the cap path, temporarily lower `MAX_UIA_ITERATIONS` and confirm `searchTruncated: true`.

Co-Authored-By: Devin AI &lt;158243242+devin-ai-integration[bot]@users.noreply.github.com&gt;